### PR TITLE
FIx to fits_image_display.py for command line use.

### DIFF
--- a/src/fits_image_display.py
+++ b/src/fits_image_display.py
@@ -1628,9 +1628,10 @@ if __name__ == "__main__":
     root = Tk.Tk()
     root.title('Image Display Widget')
     imdisp = ImageGUI(root)
-    if '.fits' in sys.argv[-1]:
-        imdisp.imagename = sys.argv[-1]
-        imdisp.get_image()
     imdisp.make_image_window()
+    if '.fits' in sys.argv[-1]:
+        imdisp.imagefilename = sys.argv[-1]
+        imdisp.image = imdisp.get_image()
+        imdisp.displayImage()
     root.mainloop()
 


### PR DESCRIPTION
Although the intent is to use fits_image_display.py via the interface, I discovered that it was not working from the command line anymore.  A few changes to the main program part were made to fix this.